### PR TITLE
Disable auto login on service build

### DIFF
--- a/Connector/ZimbraConnector.php
+++ b/Connector/ZimbraConnector.php
@@ -52,6 +52,10 @@ class ZimbraConnector
      */
     private $sessionPath;
 
+    /**
+     * @var bool
+     */
+    private $login_init = false;
 
     /**
      * @param \Synaq\CurlBundle\Curl\Wrapper $httpClient
@@ -77,6 +81,9 @@ class ZimbraConnector
     private function request($requestType, $attributes = array(), $parameters = array(), $delegate = false, $delegateType = 'Mail', $retryOnExpiredAuth = true)
     {
         try {
+            if(!$this->login_init && !$this->authToken) {
+                $this->login();
+            }
             $request = $this->buildRequest($requestType, $attributes, $parameters, $delegate, $delegateType);
             $response = $this->submitRequest($request);
             $response = $response['soap:Envelope']['soap:Body'][$requestType . 'Response'];
@@ -239,6 +246,7 @@ class ZimbraConnector
     public function login()
     {
         $this->authToken = null;
+        $this->login_init = true;
         $response = $this->request('Auth', array(), array('name' => $this->adminUser, 'password' => $this->adminPass));
         $this->authToken = $response['authToken'];
         if (!empty($this->sessionPath)) {

--- a/Connector/ZimbraConnector.php
+++ b/Connector/ZimbraConnector.php
@@ -69,9 +69,7 @@ class ZimbraConnector
         $this->fopen = $fopen;
         $this->sessionPath = $sessionPath;
 
-        if (empty($this->sessionPath) || !file_exists($this->sessionPath)) {
-            $this->login();
-        } else {
+        if (!empty($this->sessionPath) && file_exists($this->sessionPath)) {
             $this->authToken = file_get_contents($this->sessionPath);
         }
     }


### PR DESCRIPTION
Login is triggered on service build, so if there is a problem with zimbra server it thrown an 500 error on application loading
As login is automaticaly triggered on request i've just disabled the login call in constructor to solve this issue.